### PR TITLE
Handle expanded tokens, especially for EGL

### DIFF
--- a/auto/bin/make.pl
+++ b/auto/bin/make.pl
@@ -11,7 +11,7 @@ my %regex = (
     extname  => qr/^[A-Z][A-Za-z0-9_]+$/,
     exturl   => qr/^http.+$/,
     function => qr/^(.+) ([a-z][a-z0-9_]*) \((.*)\)$/i,
-    token    => qr/^([A-Z][A-Z0-9_x]*)\s+((?:0x)?[0-9A-Fa-f]+(u(ll)?)?|[A-Z][A-Z0-9_]*)$/,
+    token    => qr/^([A-Z][A-Za-z0-9_x]*)\s+((?:0x|-)?[0-9A-Fa-f]+(u(ll)?)?|[A-Z][A-Za-z0-9(),_-]*)$/,
     type     => qr/^typedef\s+(.+)$/,
     exact    => qr/.*;$/,
 );


### PR DESCRIPTION
Extensions, especially EGL, now have tokens like:

```
EGL_TIMESTAMP_PENDING_ANDROID EGL_CAST(EGLnsecsANDROID,-2)
EGL_COLORSPACE_sRGB 0x3089
EGL_NO_NATIVE_FENCE_FD_ANDROID -1
```

which the previous `token` regex wasn't matching.  This PR expands it out to include lowercase letters, the EGL_CAST() syntax, and negative numbers.